### PR TITLE
Changed SwitchController to be a singleton.

### DIFF
--- a/Assets/Scripts/On-Off Switch/BlueBlock.cs
+++ b/Assets/Scripts/On-Off Switch/BlueBlock.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 public class BlueBlock : MonoBehaviour {
 
 	private bool isOn;
-	public SwitchController switchController; 
 	private Collider2D col;
 	private SpriteRenderer spriteR;
 	public Sprite OnSprite;
@@ -21,7 +20,7 @@ public class BlueBlock : MonoBehaviour {
 	
 	// Update is called once per frame
 	void Update () {
-		isOn = switchController.isOn;
+		isOn = SwitchController.instance.isOn;
 
 		if (!isOn) {
 			col.enabled = true;

--- a/Assets/Scripts/On-Off Switch/RedBlock.cs
+++ b/Assets/Scripts/On-Off Switch/RedBlock.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 public class RedBlock : MonoBehaviour {
 
 	private bool isOn;
-	public SwitchController switchController; 
 	private Collider2D col;
 	private SpriteRenderer spriteR;
 	public Sprite OnSprite;
@@ -21,7 +20,7 @@ public class RedBlock : MonoBehaviour {
 
 	// Update is called once per frame
 	void Update () {
-		isOn = switchController.isOn;
+		isOn = SwitchController.instance.isOn;
 
 		if (isOn) {
 			col.enabled = true;

--- a/Assets/Scripts/On-Off Switch/SwitchController.cs
+++ b/Assets/Scripts/On-Off Switch/SwitchController.cs
@@ -3,8 +3,16 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class SwitchController : MonoBehaviour {
-	
+	public static SwitchController instance = null;
 	public bool isOn;
+	
+        void Awake() {
+		if (instance == null) {
+			instance = this;
+		} else if (instance != this) {
+			Destroy(gameObject);
+		}
+        }
 
 	public void FlipSwitch () {
 		isOn = !isOn;


### PR DESCRIPTION
Hey there, great video!

I've noticed that you decided to use a reference to the SwitchController object reference in your code. While this is certainly not wrong, best practice for such Game Controllers is to use a singleton system.

This way you can ensure there is exactly one SwitchController in any scene and you don't need to drag your script into the public script slot. You could also dynamically create a SwitchController which automatically assigns itself to be "the SwitchController".

This is especially useful in cases where a level loading script would dynamically instantiate Blocks and only instantiate a SwitchController if needed.